### PR TITLE
Refactor

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -1,6 +1,6 @@
 {
   "name": "@ymjacky/mqtt5",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "exports": {
     ".": "./deno/mod.ts",
     "./browser": "./browser/mod.ts"

--- a/lib/client/base_mqtt_client.ts
+++ b/lib/client/base_mqtt_client.ts
@@ -362,7 +362,7 @@ export abstract class BaseMqttClient {
       await this.sendPacket(packet);
       deferred.resolve({ result: 0, reason: '' });
     } else {
-      const packetId = await this.session.aquirePacketId();
+      const packetId = await this.session.acquirePacketId();
       const packet: PublishPacket = {
         type: 'publish',
         topic,
@@ -475,7 +475,7 @@ export abstract class BaseMqttClient {
     const deferred = new Deferred<SubscribeResults>();
     const packet: SubscribePacket = {
       type: 'subscribe',
-      packetId: await this.session.aquirePacketId(),
+      packetId: await this.session.acquirePacketId(),
       subscriptions: subs,
       properties: properties,
     };
@@ -534,7 +534,7 @@ export abstract class BaseMqttClient {
     const deferred = new Deferred<UnsubscribeResults>();
     const packet: UnsubscribePacket = {
       type: 'unsubscribe',
-      packetId: await this.session.aquirePacketId(),
+      packetId: await this.session.acquirePacketId(),
       topicFilters: unsubs,
       properties,
     };

--- a/lib/client/session.ts
+++ b/lib/client/session.ts
@@ -26,8 +26,8 @@ export class Session {
     return this.sessionId;
   }
 
-  public async aquirePacketId() {
-    return await this.packetIdProvider.aquire();
+  public async acquirePacketId() {
+    return await this.packetIdProvider.acquire();
   }
 
   public async clearAllStores(newSessionId?: string) {

--- a/lib/client/topic_alias.ts
+++ b/lib/client/topic_alias.ts
@@ -43,7 +43,7 @@ export class TopicAliasManager {
       if (tid) {
         this.topicIdProvider.release(tid);
       }
-      const topicId = await this.aquireTopicId();
+      const topicId = await this.acquireTopicId();
       this.topicAliasMap.set(topic, topicId);
       return topicId;
     } else {
@@ -58,7 +58,7 @@ export class TopicAliasManager {
         }
       }
 
-      const topicId = await this.aquireTopicId();
+      const topicId = await this.acquireTopicId();
       this.topicAliasMap.set(topic, topicId);
       return topicId;
     }
@@ -74,7 +74,7 @@ export class TopicAliasManager {
     }
   }
 
-  private async aquireTopicId() {
-    return await this.topicIdProvider.aquire();
+  private async acquireTopicId() {
+    return await this.topicIdProvider.acquire();
   }
 }

--- a/lib/id_provider/reuse_id_provider.ts
+++ b/lib/id_provider/reuse_id_provider.ts
@@ -28,7 +28,7 @@ export class ReuseIdProvider {
     this._next = this._start;
   }
 
-  public aquire(): number {
+  public acquire(): number {
     let id = this._reusable.shift(); // remove first entry
     if (id) { // found
       this._reuse.push(id);

--- a/lib/mqtt_packets/puback.ts
+++ b/lib/mqtt_packets/puback.ts
@@ -68,15 +68,28 @@ export function parse(
   const properties = (() => {
     const { number: length, size: consumedBytesSize } = variableByteIntegerToNum(buffer, pos);
     pos += consumedBytesSize;
-    const prop = MqttProperties.parseMqttProperties(buffer, pos, length);
-    pos += length;
-    return prop;
+
+    if (length > 0) {
+      const prop = MqttProperties.parseMqttProperties(buffer, pos, length);
+      pos += length;
+      return prop;
+    } else {
+      return undefined;
+    }
   })();
 
-  return {
-    type: 'puback',
-    packetId: packetId,
-    reasonCode: reasonCode,
-    properties: properties,
-  };
+  if (properties) {
+    return {
+      type: 'puback',
+      packetId: packetId,
+      reasonCode: reasonCode,
+      properties: properties,
+    };
+  } else {
+    return {
+      type: 'puback',
+      packetId: packetId,
+      reasonCode: reasonCode,
+    };
+  }
 }

--- a/lib/mqtt_packets/pubcomp.ts
+++ b/lib/mqtt_packets/pubcomp.ts
@@ -68,15 +68,28 @@ export function parse(
   const properties = (() => {
     const { number: length, size: consumedBytesSize } = variableByteIntegerToNum(buffer, pos);
     pos += consumedBytesSize;
-    const prop = MqttProperties.parseMqttProperties(buffer, pos, length);
-    pos += length;
-    return prop;
+
+    if (length > 0) {
+      const prop = MqttProperties.parseMqttProperties(buffer, pos, length);
+      pos += length;
+      return prop;
+    } else {
+      return undefined;
+    }
   })();
 
-  return {
-    type: 'pubcomp',
-    packetId: packetId,
-    reasonCode: reasonCode,
-    properties: properties,
-  };
+  if (properties) {
+    return {
+      type: 'pubcomp',
+      packetId: packetId,
+      reasonCode: reasonCode,
+      properties: properties,
+    };
+  } else {
+    return {
+      type: 'pubcomp',
+      packetId: packetId,
+      reasonCode: reasonCode,
+    };
+  }
 }

--- a/lib/mqtt_packets/pubrel.ts
+++ b/lib/mqtt_packets/pubrel.ts
@@ -44,7 +44,7 @@ export function parse(
   let pos = 0;
 
   if (remainingLength < 2) {
-    throw new MqttUtilsError.RemainingLengthError('pubrec packet');
+    throw new MqttUtilsError.RemainingLengthError('pubrel packet');
   }
   const packetId = twoByteIntegerToNum(buffer, pos);
   pos += 2;
@@ -68,15 +68,28 @@ export function parse(
   const properties = (() => {
     const { number: length, size: consumedBytesSize } = variableByteIntegerToNum(buffer, pos);
     pos += consumedBytesSize;
-    const prop = MqttProperties.parseMqttProperties(buffer, pos, length);
-    pos += length;
-    return prop;
+
+    if (length > 0) {
+      const prop = MqttProperties.parseMqttProperties(buffer, pos, length);
+      pos += length;
+      return prop;
+    } else {
+      return undefined;
+    }
   })();
 
-  return {
-    type: 'pubrel',
-    packetId: packetId,
-    reasonCode: reasonCode,
-    properties: properties,
-  };
+  if (properties) {
+    return {
+      type: 'pubrel',
+      packetId: packetId,
+      reasonCode: reasonCode,
+      properties: properties,
+    };
+  } else {
+    return {
+      type: 'pubrel',
+      packetId: packetId,
+      reasonCode: reasonCode,
+    };
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 
 ``mqtt5`` supports Mqtt protocol versions 5.0 and 3.1.1.
 
-We have confirmed that deno version 1.44.2 or later works.
+We have confirmed that deno version 2.3.1 or later works.
 
 ## Usage
 

--- a/test/deno/id_provider/reuse_id_provider_test.ts
+++ b/test/deno/id_provider/reuse_id_provider_test.ts
@@ -4,133 +4,133 @@ import { ReuseIdProvider as IdProvider } from '../../../lib/id_provider/reuse_id
 
 Deno.test('increment', () => {
   const idProvider = new IdProvider(1, 9);
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 2);
-  assertEquals(idProvider.aquire(), 3);
-  assertEquals(idProvider.aquire(), 4);
-  assertEquals(idProvider.aquire(), 5);
-  assertEquals(idProvider.aquire(), 6);
-  assertEquals(idProvider.aquire(), 7);
-  assertEquals(idProvider.aquire(), 8);
-  assertEquals(idProvider.aquire(), 9);
-  assertThrows(() => idProvider.aquire());
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 2);
+  assertEquals(idProvider.acquire(), 3);
+  assertEquals(idProvider.acquire(), 4);
+  assertEquals(idProvider.acquire(), 5);
+  assertEquals(idProvider.acquire(), 6);
+  assertEquals(idProvider.acquire(), 7);
+  assertEquals(idProvider.acquire(), 8);
+  assertEquals(idProvider.acquire(), 9);
+  assertThrows(() => idProvider.acquire());
 });
 
 Deno.test('reuse_1', () => {
   const idProvider = new IdProvider(1, 9);
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 2);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 2);
   assert(idProvider.release(1));
   assert(idProvider.release(2));
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 2);
-  assertEquals(idProvider.aquire(), 3);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 2);
+  assertEquals(idProvider.acquire(), 3);
   assert(idProvider.release(1));
   assert(idProvider.release(2));
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 2);
-  assertEquals(idProvider.aquire(), 4);
-  assertEquals(idProvider.aquire(), 5);
-  assertEquals(idProvider.aquire(), 6);
-  assertEquals(idProvider.aquire(), 7);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 2);
+  assertEquals(idProvider.acquire(), 4);
+  assertEquals(idProvider.acquire(), 5);
+  assertEquals(idProvider.acquire(), 6);
+  assertEquals(idProvider.acquire(), 7);
   assert(idProvider.release(3));
-  assertEquals(idProvider.aquire(), 3);
-  assertEquals(idProvider.aquire(), 8);
-  assertEquals(idProvider.aquire(), 9);
-  assertThrows(() => idProvider.aquire());
+  assertEquals(idProvider.acquire(), 3);
+  assertEquals(idProvider.acquire(), 8);
+  assertEquals(idProvider.acquire(), 9);
+  assertThrows(() => idProvider.acquire());
 });
 
 Deno.test('reuse_2', () => {
   const idProvider = new IdProvider(1, 9);
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 2);
-  assertEquals(idProvider.aquire(), 3);
-  assertEquals(idProvider.aquire(), 4);
-  assertEquals(idProvider.aquire(), 5);
-  assertEquals(idProvider.aquire(), 6);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 2);
+  assertEquals(idProvider.acquire(), 3);
+  assertEquals(idProvider.acquire(), 4);
+  assertEquals(idProvider.acquire(), 5);
+  assertEquals(idProvider.acquire(), 6);
   assert(idProvider.release(6));
   assert(idProvider.release(5));
   assert(idProvider.release(4));
   assert(idProvider.release(3));
-  assertEquals(idProvider.aquire(), 3);
-  assertEquals(idProvider.aquire(), 4);
-  assertEquals(idProvider.aquire(), 5);
-  assertEquals(idProvider.aquire(), 6);
+  assertEquals(idProvider.acquire(), 3);
+  assertEquals(idProvider.acquire(), 4);
+  assertEquals(idProvider.acquire(), 5);
+  assertEquals(idProvider.acquire(), 6);
 });
 
 Deno.test('reuse_3', () => {
   const idProvider = new IdProvider(1, 9);
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 2);
-  assertEquals(idProvider.aquire(), 3);
-  assertEquals(idProvider.aquire(), 4);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 2);
+  assertEquals(idProvider.acquire(), 3);
+  assertEquals(idProvider.acquire(), 4);
   assert(idProvider.release(1));
   assert(idProvider.release(2));
   assert(idProvider.release(3));
   assert(idProvider.release(4));
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 2);
-  assertEquals(idProvider.aquire(), 3);
-  assertEquals(idProvider.aquire(), 4);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 2);
+  assertEquals(idProvider.acquire(), 3);
+  assertEquals(idProvider.acquire(), 4);
   assert(idProvider.release(1));
   assert(idProvider.release(2));
   assert(idProvider.release(3));
   assert(idProvider.release(4));
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 2);
-  assertEquals(idProvider.aquire(), 3);
-  assertEquals(idProvider.aquire(), 4);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 2);
+  assertEquals(idProvider.acquire(), 3);
+  assertEquals(idProvider.acquire(), 4);
 });
 
 Deno.test('reuse_4', () => {
   const idProvider = new IdProvider(1, 9);
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 2);
-  assertEquals(idProvider.aquire(), 3);
-  assertEquals(idProvider.aquire(), 4);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 2);
+  assertEquals(idProvider.acquire(), 3);
+  assertEquals(idProvider.acquire(), 4);
   assert(idProvider.release(1));
   assert(idProvider.release(2));
   assert(idProvider.release(3));
   assert(idProvider.release(4));
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 2);
-  assertEquals(idProvider.aquire(), 3);
-  assertEquals(idProvider.aquire(), 4);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 2);
+  assertEquals(idProvider.acquire(), 3);
+  assertEquals(idProvider.acquire(), 4);
   assert(idProvider.release(4));
   assert(idProvider.release(3));
   assert(idProvider.release(2));
   assert(idProvider.release(1));
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 2);
-  assertEquals(idProvider.aquire(), 3);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 2);
+  assertEquals(idProvider.acquire(), 3);
 });
 
 Deno.test('reuse_5', () => {
   const idProvider = new IdProvider(1, 9);
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 2);
-  assertEquals(idProvider.aquire(), 3);
-  assertEquals(idProvider.aquire(), 4);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 2);
+  assertEquals(idProvider.acquire(), 3);
+  assertEquals(idProvider.acquire(), 4);
   assert(idProvider.release(3));
   assert(idProvider.release(2));
   assert(idProvider.release(1));
-  assertEquals(idProvider.aquire(), 3);
+  assertEquals(idProvider.acquire(), 3);
   assert(idProvider.release(4));
-  assertEquals(idProvider.aquire(), 2);
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 4);
+  assertEquals(idProvider.acquire(), 2);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 4);
   assert(idProvider.release(4));
   assert(idProvider.release(1));
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 4);
-  assertEquals(idProvider.aquire(), 5);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 4);
+  assertEquals(idProvider.acquire(), 5);
 });
 
 Deno.test('registerIfNotInUse_1', () => {
   const idProvider = new IdProvider(1, 9);
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 2);
-  assertEquals(idProvider.aquire(), 3);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 2);
+  assertEquals(idProvider.acquire(), 3);
 
   assertFalse(idProvider.registerIfNotInUse(1));
   assertFalse(idProvider.registerIfNotInUse(2));
@@ -139,40 +139,40 @@ Deno.test('registerIfNotInUse_1', () => {
   assert(idProvider.registerIfNotInUse(6));
   assertFalse(idProvider.registerIfNotInUse(6));
 
-  assertEquals(idProvider.aquire(), 7);
-  assertEquals(idProvider.aquire(), 8);
+  assertEquals(idProvider.acquire(), 7);
+  assertEquals(idProvider.acquire(), 8);
 });
 
 Deno.test('registerIfNotInUse_2', () => {
   const idProvider = new IdProvider(1, 9);
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 2);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 2);
 
   assert(idProvider.registerIfNotInUse(6));
   assert(idProvider.registerIfNotInUse(3));
 
-  assertEquals(idProvider.aquire(), 7);
-  assertEquals(idProvider.aquire(), 8);
+  assertEquals(idProvider.acquire(), 7);
+  assertEquals(idProvider.acquire(), 8);
 });
 
 Deno.test('registerIfNotInUse_3', () => {
   const idProvider = new IdProvider(1, 9);
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 2);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 2);
 
   assert(idProvider.registerIfNotInUse(6));
   assert(idProvider.registerIfNotInUse(3));
 
   assert(idProvider.release(6));
 
-  assertEquals(idProvider.aquire(), 6);
-  assertEquals(idProvider.aquire(), 7);
+  assertEquals(idProvider.acquire(), 6);
+  assertEquals(idProvider.acquire(), 7);
 });
 
 Deno.test('registerIfNotInUse_4', () => {
   const idProvider = new IdProvider(1, 9);
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 2);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 2);
 
   assert(idProvider.registerIfNotInUse(6));
   assert(idProvider.registerIfNotInUse(3));
@@ -180,27 +180,27 @@ Deno.test('registerIfNotInUse_4', () => {
   assert(idProvider.release(6));
   assert(idProvider.release(3));
 
-  assertEquals(idProvider.aquire(), 3); // from reusable
-  assertEquals(idProvider.aquire(), 6); // from next
+  assertEquals(idProvider.acquire(), 3); // from reusable
+  assertEquals(idProvider.acquire(), 6); // from next
 
   assert(idProvider.release(6)); // next -> 6
   assert(idProvider.release(3)); // 3 -> resusable
-  assertEquals(idProvider.aquire(), 3); // from reusable
+  assertEquals(idProvider.acquire(), 3); // from reusable
 });
 
 Deno.test('registerIfNotInUse_5', () => {
   const idProvider = new IdProvider(1, 9);
-  assertEquals(idProvider.aquire(), 1);
-  assertEquals(idProvider.aquire(), 2);
+  assertEquals(idProvider.acquire(), 1);
+  assertEquals(idProvider.acquire(), 2);
 
   assert(idProvider.registerIfNotInUse(6));
   assert(idProvider.release(6));
 
-  assertEquals(idProvider.aquire(), 6);
+  assertEquals(idProvider.acquire(), 6);
   assert(idProvider.release(6));
 
-  assertEquals(idProvider.aquire(), 6);
-  assertEquals(idProvider.aquire(), 7);
-  assertEquals(idProvider.aquire(), 8);
-  assertEquals(idProvider.aquire(), 9);
+  assertEquals(idProvider.acquire(), 6);
+  assertEquals(idProvider.acquire(), 7);
+  assertEquals(idProvider.acquire(), 8);
+  assertEquals(idProvider.acquire(), 9);
 });


### PR DESCRIPTION
This pull request includes several updates to the MQTT5 library, focusing on fixing typos in method names, improving error handling, and updating documentation. The most significant changes involve renaming the misspelled `aquire` methods to `acquire`, adding guards for property parsing, and updating the supported Deno version in the documentation.

### Method Renaming and Refactoring:
* Renamed all instances of the misspelled `aquire` to `acquire` across multiple files, including `BaseMqttClient`, `Session`, `TopicAliasManager`, and `ReuseIdProvider`. This change ensures consistency and correctness in method naming. [[1]](diffhunk://#diff-81f08816afa2cadb74672e033e66993432347137f14f0fa7132e0325b4b4f137L365-R365) [[2]](diffhunk://#diff-81f08816afa2cadb74672e033e66993432347137f14f0fa7132e0325b4b4f137L478-R478) [[3]](diffhunk://#diff-81f08816afa2cadb74672e033e66993432347137f14f0fa7132e0325b4b4f137L537-R537) [[4]](diffhunk://#diff-d45df505bd5cda1084ed9c6ffb6b11b5e7527590858a3d8c243b1eca60915fa2L29-R30) [[5]](diffhunk://#diff-c03469cef54edc187ec2d96afb5e3c27bc81f980d2bc39c474e07bde89c1f606L46-R46) [[6]](diffhunk://#diff-c03469cef54edc187ec2d96afb5e3c27bc81f980d2bc39c474e07bde89c1f606L61-R61) [[7]](diffhunk://#diff-c03469cef54edc187ec2d96afb5e3c27bc81f980d2bc39c474e07bde89c1f606L77-R78) [[8]](diffhunk://#diff-b5d558ecd374e82472f71b0274ddf6a69c8f020c7233fa71d2f12ca4961f5819L31-R31)

### Parsing Enhancements:
* Added guards to handle cases where property lengths are zero in the `parse` functions for MQTT packets like `puback`, `pubcomp`, and `pubrel`. This prevents potential errors during property parsing. [[1]](diffhunk://#diff-7e7d87ede4d3225fbd479b7df2f451b36bf37b137892e07de6225f7c3b216387R71-R94) [[2]](diffhunk://#diff-2b90cae2dcd9522de11f1ea9e56a0766aa1c15e4c96efc06e86b2635e67ffc13R71-R94) [[3]](diffhunk://#diff-e093f5ea4eea507947bf92e9f8788489adea954f8c0ec6ec2fa8dc88ac803490R71-R94)

### Documentation Updates:
* Updated the supported Deno version in the `readme.md` file from `1.44.2` to `2.3.1`, reflecting the latest compatibility requirements.

### Error Message Fix:
* Corrected an error message in the `pubrel` packet parser to reference the correct packet type.

### Test Updates:
* Updated all test cases in `reuse_id_provider_test.ts` to use the corrected `acquire` method name, ensuring consistency with the refactored code. [[1]](diffhunk://#diff-49901d6d54211d496d647bd6624af8bbbfe4b53885ac6b6f3349487b1960642aL7-R133) [[2]](diffhunk://#diff-49901d6d54211d496d647bd6624af8bbbfe4b53885ac6b6f3349487b1960642aL142-R205)